### PR TITLE
LiveDisplayManager.java: Prevent QS tile creation failure

### DIFF
--- a/sdk/src/java/lineageos/hardware/LiveDisplayManager.java
+++ b/sdk/src/java/lineageos/hardware/LiveDisplayManager.java
@@ -160,7 +160,7 @@ public class LiveDisplayManager {
         try {
             mConfig = sService.getConfig();
             if (mConfig == null) {
-                throw new RuntimeException("Unable to get LiveDisplay configuration!");
+                 Log.w(TAG, "Unable to get LiveDisplay configuration!");
             }
         } catch (RemoteException e) {
             throw new RuntimeException("Unable to fetch LiveDisplay configuration!", e);


### PR DESCRIPTION
Suggested fix for LiveDisplay quick tile disappearing on reboot. Don't throw exception, warning is enough.
See comments Re: tile disappearing: https://review.lineageos.org/#/c/195586/

Original CM fix credit: Pranav Vashi (<neobuddy89@gmail.com>) 
See related: https://github.com/crdroidandroid/cm_platform_sdk/commit/a3324fb44f4d3e5a2d6714abf9f68354aec4b0b8